### PR TITLE
Fixed Liquid Conditional Statements

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,14 +6,14 @@
             <p class="intro__post">{{ site.location }}</p>
         </div>
 
-        {{ if site.github_username or site.codepen_username or site.twitter_username or site.email_address }}
+        {$ if site.github_username or site.codepen_username or site.twitter_username or site.email_address $}
         <div class="social">
-            {{ if site.github_username }}<a href="http://github.com/{{ site.github_username }}" target="_blank">GitHub</a>{{ endif }}
-            {{ if site.codepen_username }}<a href="http://codepen.io/{{ site.codepen_username }}" target="_blank">CodePen</a>{{ endif }}
-            {{ if site.twitter_username }}<a href="http://twitter.com/{{ site.twitter_username }}" target="_blank">Twitter</a>{{ endif }}
-            {{ if site.email_address }}<a href="mailto:{{ site.email_address }}" target="_blank">Email</a>{{ endif }}
+            {$ if site.github_username $}<a href="http://github.com/{{ site.github_username }}" target="_blank">GitHub</a>{$ endif $}
+            {$ if site.codepen_username $}<a href="http://codepen.io/{{ site.codepen_username }}" target="_blank">CodePen</a>{$ endif $}
+            {$ if site.twitter_username $}<a href="http://twitter.com/{{ site.twitter_username }}" target="_blank">Twitter</a>{$ endif $}
+            {$ if site.email_address $}<a href="mailto:{{ site.email_address }}" target="_blank">Email</a>{$ endif $}
         </div>
-        {{ endif }}
+        {$ endif $}
 
     </div>
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,14 +6,14 @@
             <p class="intro__post">{{ site.location }}</p>
         </div>
 
-        {$ if site.github_username or site.codepen_username or site.twitter_username or site.email_address $}
+        {% if site.github_username or site.codepen_username or site.twitter_username or site.email_address %}
         <div class="social">
-            {$ if site.github_username $}<a href="http://github.com/{{ site.github_username }}" target="_blank">GitHub</a>{$ endif $}
-            {$ if site.codepen_username $}<a href="http://codepen.io/{{ site.codepen_username }}" target="_blank">CodePen</a>{$ endif $}
-            {$ if site.twitter_username $}<a href="http://twitter.com/{{ site.twitter_username }}" target="_blank">Twitter</a>{$ endif $}
-            {$ if site.email_address $}<a href="mailto:{{ site.email_address }}" target="_blank">Email</a>{$ endif $}
+            {% if site.github_username %}<a href="http://github.com/{{ site.github_username }}" target="_blank">GitHub</a>{% endif %}
+            {% if site.codepen_username %}<a href="http://codepen.io/{{ site.codepen_username }}" target="_blank">CodePen</a>{% endif %}
+            {% if site.twitter_username %}<a href="http://twitter.com/{{ site.twitter_username }}" target="_blank">Twitter</a>{% endif %}
+            {% if site.email_address %}<a href="mailto:{{ site.email_address }}" target="_blank">Email</a>{% endif %}
         </div>
-        {$ endif $}
+        {% endif %}
 
     </div>
 </header>


### PR DESCRIPTION
There was a bug in liquid syntax that was silently failing. The wrong liquid delimiters were being used for the conditional statements in the header.html file.